### PR TITLE
feat:タスク一覧画面の作成 #8

### DIFF
--- a/frontend/lib/api/firebase_api_client.dart
+++ b/frontend/lib/api/firebase_api_client.dart
@@ -8,10 +8,10 @@ class FirebaseApiClient {
     ApiConfig? config,
     bool forceRefreshToken = false,
   }) {
-    final c = config ?? ApiConfig.fromEnvironment();
+    final configInstance = config ?? ApiConfig.fromEnvironment();
 
     return ApiClient(
-      config: c,
+      config: configInstance,
       tokenProvider: () => getFirebaseIdToken(forceRefresh: forceRefreshToken),
     );
   }

--- a/frontend/lib/features/tasks/tasks_api.dart
+++ b/frontend/lib/features/tasks/tasks_api.dart
@@ -1,0 +1,15 @@
+import '../../api/api.dart';
+import '../../models/task.dart';
+
+class TasksApi {
+  TasksApi({ApiClient? client}) : _client = client ?? FirebaseApiClient.create();
+
+  final ApiClient _client;
+
+  Future<List<Task>> fetchTasks() {
+    return _client.get<List<Task>>(
+      '/tasks',
+      decoder: (json) => Task.listFromJson(json),
+    );
+  }
+}

--- a/frontend/lib/features/tasks/tasks_screen.dart
+++ b/frontend/lib/features/tasks/tasks_screen.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../../api/api.dart';
+import '../../models/task.dart';
+import '../../widgets/app_loading_indicator.dart';
+
+import 'tasks_api.dart';
+
+class TasksScreen extends StatefulWidget {
+  const TasksScreen({super.key});
+
+  @override
+  State<TasksScreen> createState() => _TasksScreenState();
+}
+
+class _TasksScreenState extends State<TasksScreen> {
+  late Future<List<Task>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = TasksApi().fetchTasks();
+  }
+
+  void _reload() {
+    setState(() {
+      _future = TasksApi().fetchTasks();
+    });
+  }
+
+  String _errorText(Object error) {
+    if (error is ApiException) {
+      return error.message;
+    }
+    return 'タスクの取得に失敗しました';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Tasks'),
+        actions: [
+          IconButton(
+            onPressed: _reload,
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Reload',
+          ),
+        ],
+      ),
+      body: FutureBuilder<List<Task>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: AppLoadingIndicator(size: 24, strokeWidth: 3));
+          }
+
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(_errorText(snapshot.error!)),
+                    const SizedBox(height: 12),
+                    ElevatedButton(
+                      onPressed: _reload,
+                      child: const Text('再読み込み'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          }
+
+          final tasks = snapshot.data ?? const <Task>[];
+
+          if (tasks.isEmpty) {
+            return const Center(child: Text('タスクがありません'));
+          }
+
+          return ListView.separated(
+            itemCount: tasks.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (context, index) {
+              final task = tasks[index];
+              return ListTile(
+                leading: Icon(task.isDone ? Icons.check_circle : Icons.radio_button_unchecked),
+                title: Text(task.title.isEmpty ? '(no title)' : task.title),
+                subtitle: task.id.isEmpty ? null : Text(task.id),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend/lib/models/task.dart
+++ b/frontend/lib/models/task.dart
@@ -1,0 +1,52 @@
+class Task {
+  Task({
+    required this.id,
+    required this.title,
+    required this.isDone,
+  });
+
+  final String id;
+  final String title;
+  final bool isDone;
+
+  factory Task.fromJson(Map<String, dynamic> json) {
+    final title = (json['title'] ?? json['name'] ?? '').toString();
+    final id = (json['id'] ?? json['taskId'] ?? '').toString();
+    final doneRaw = json['isDone'] ?? json['done'] ?? json['completed'] ?? false;
+
+    return Task(
+      id: id,
+      title: title,
+      isDone: doneRaw == true,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'isDone': isDone,
+    };
+  }
+
+  static List<Task> listFromJson(dynamic json) {
+    if (json is List) {
+      return json
+          .whereType<Map>()
+          .map((e) => Task.fromJson(Map<String, dynamic>.from(e)))
+          .toList();
+    }
+
+    if (json is Map) {
+      final tasks = json['tasks'];
+      if (tasks is List) {
+        return tasks
+            .whereType<Map>()
+            .map((e) => Task.fromJson(Map<String, dynamic>.from(e)))
+            .toList();
+      }
+    }
+
+    return const [];
+  }
+}

--- a/frontend/lib/screens/task_screen.dart
+++ b/frontend/lib/screens/task_screen.dart
@@ -1,15 +1,12 @@
 import 'package:flutter/material.dart';
 
+import '../features/tasks/tasks_screen.dart';
+
 class TaskScreen extends StatelessWidget {
   const TaskScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Tasks')),
-      body: const Center(
-        child: Text('タスク画面（仮）'),
-      ),
-    );
+    return const TasksScreen();
   }
 }


### PR DESCRIPTION
## 関連 Issue

Closes #8

## やったこと
指定のディレクトリ構成に沿って、タスク一覧UI + ローディング/空/エラー状態 + API接続まで実装しました。
## 追加したライブラリ、パッケージ

## 動作確認

- [ ] ビルドできた

## 参考にした資料

<!-- I want to review in Japanese. -->
<!-- 日本語でレビューしてください -->

#### レビューの接頭語

[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報