### PR TITLE
認証ユーザーのタスク一覧取得の作成 #17

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -105,7 +105,7 @@ func main() {
 	mux.Handle(
 		"/tasks",
 		middleware.RequireFirebaseAuth(verifier, userRepo)(
-			http.HandlerFunc(taskHandler.Create),
+			taskHandler,
 		),
 	)
 

--- a/backend/internal/handler/task_handler.go
+++ b/backend/internal/handler/task_handler.go
@@ -25,6 +25,37 @@ type errorResponse struct {
 	Error string `json:"error"`
 }
 
+type listTasksResponse struct {
+	Tasks any `json:"tasks"`
+}
+
+func (h *TaskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.List(w, r)
+	case http.MethodPost:
+		h.Create(w, r)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *TaskHandler) List(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	tasks, err := h.tasks.ListTasks(r.Context(), userID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "internal_server_error"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, listTasksResponse{Tasks: tasks})
+}
+
 func (h *TaskHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/backend/internal/repository/task_repository.go
+++ b/backend/internal/repository/task_repository.go
@@ -51,3 +51,49 @@ RETURNING id, user_id, title, is_done, due_at, scheduled_at, created_at, updated
 
 	return t, nil
 }
+
+func (r *TaskRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]model.Task, error) {
+	rows, err := r.db.QueryContext(
+		ctx,
+		`SELECT id, user_id, title, is_done, due_at, scheduled_at, created_at, updated_at
+FROM tasks
+WHERE user_id = $1
+ORDER BY is_done ASC, COALESCE(due_at, 'infinity'::timestamptz) ASC, created_at DESC;`,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []model.Task
+	for rows.Next() {
+		var t model.Task
+		var dueAt sql.NullTime
+		var scheduledAt sql.NullTime
+		if err := rows.Scan(
+			&t.ID,
+			&t.UserID,
+			&t.Title,
+			&t.IsDone,
+			&dueAt,
+			&scheduledAt,
+			&t.CreatedAt,
+			&t.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if dueAt.Valid {
+			t.DueAt = &dueAt.Time
+		}
+		if scheduledAt.Valid {
+			t.ScheduledAt = &scheduledAt.Time
+		}
+		out = append(out, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}

--- a/backend/internal/service/task_service.go
+++ b/backend/internal/service/task_service.go
@@ -15,11 +15,21 @@ type TaskCreator interface {
 	Create(ctx context.Context, userID uuid.UUID, title string) (model.Task, error)
 }
 
-type TaskService struct {
-	repo TaskCreator
+type TaskLister interface {
+	ListByUser(ctx context.Context, userID uuid.UUID) ([]model.Task, error)
 }
 
-func NewTaskService(repo TaskCreator) *TaskService {
+type TaskService struct {
+	repo interface {
+		TaskCreator
+		TaskLister
+	}
+}
+
+func NewTaskService(repo interface {
+	TaskCreator
+	TaskLister
+}) *TaskService {
 	return &TaskService{repo: repo}
 }
 
@@ -29,4 +39,8 @@ func (s *TaskService) CreateTask(ctx context.Context, userID uuid.UUID, title st
 		return model.Task{}, ErrInvalidTaskTitle
 	}
 	return s.repo.Create(ctx, userID, title)
+}
+
+func (s *TaskService) ListTasks(ctx context.Context, userID uuid.UUID) ([]model.Task, error) {
+	return s.repo.ListByUser(ctx, userID)
 }


### PR DESCRIPTION
## 関連 Issue

Closes #

## やったこと
認証ユーザーのタスク一覧取得を追加。
tasksはGET/POST を同一ハンドラで振り分けるように整理。
## 追加したライブラリ、パッケージ

## 動作確認

- [ ] ビルドできた

## 参考にした資料

<!-- I want to review in Japanese. -->
<!-- 日本語でレビューしてください -->

#### レビューの接頭語

[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報